### PR TITLE
build: fix build tests

### DIFF
--- a/pulsar-client-cpp/CMakeLists.txt
+++ b/pulsar-client-cpp/CMakeLists.txt
@@ -345,9 +345,14 @@ include_directories(
   ${CURL_INCLUDE_DIRS}
   ${Protobuf_INCLUDE_DIRS}
   ${LOG4CXX_INCLUDE_PATH}
-  ${GTEST_INCLUDE_PATH}
-  ${GMOCK_INCLUDE_PATH}
 )
+
+if(BUILD_TESTS)
+  include_directories(
+    ${GTEST_INCLUDE_PATH}
+    ${GMOCK_INCLUDE_PATH}
+  )
+endif()
 
 set(COMMON_LIBS
   ${COMMON_LIBS}


### PR DESCRIPTION
### Motivation
When the pulsar-client-cpp is built with `cmake . -DBUILD_TESTS=OFF`, the cmake stil would look for the  `GTEST_INCLUDE_PATH` and `GMOCK_INCLUDE_PATH`, which leads the problem in #1964.
<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

### Modifications
* remove gtest/gmock from the `include_directories` of `CMakeLists.txt` when the `BUILD_TESTS=OFF`.
<!-- Describe the modifications you've done. -->

### Verifying this change

- [x] Make sure that the change passes the CI checks.


This change is a trivial rework / code cleanup without any test coverage.


### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [x] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
(Please explain why)

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
